### PR TITLE
Small skill structure updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ This repository contains agent skills for Cloudinary.
 
 | Skill | Description |
 |-------|-------------|
-| **cloudinary-docs** | Look up Cloudinary documentation using llms.txt and sanitized markdown; use when answering general Cloudinary questions or integrating Cloudinary. |
-| **cloudinary-react** | React-specific patterns, best practices, import reference, and common errors for the Cloudinary SDK (Vite, Upload Widget, AdvancedImage/Video, overlays, signed uploads). |
-| **cloudinary-transformations** | Create and debug Cloudinary transformation URLs from natural language instructions; use when building delivery URLs, applying image/video transformations, optimizing media, or debugging transformation syntax errors. |
+| **cloudinary-docs** | Selects the most relevant markdown pages from the current documentation using the latest llms.txt. Use when answering Cloudinary questions or integrating Cloudinary into code.|
+| **cloudinary-react** | Provides opinionated React SDK patterns for configuration, common integration scenarios, and troubleshooting for frequent errors and TypeScript pitfalls. Use when developing with the Cloudinary React SDK.|
+| **cloudinary-transformations** | Turns natural-language image and video transformation requirements into valid URL transformation strings that follow Cloudinary best practices. Use when building delivery URLs, applying image/video transformations, optimizing media, or debugging transformation syntax errors. |
 
 ## Usage
 
-Install all skills in a project:
+Install all skills in a project or select the skills you want during the CLI installation:
 
 ```bash
 npx skills add cloudinary-devs/skills

--- a/skills/cloudinary-docs/SKILL.md
+++ b/skills/cloudinary-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cloudinary-docs
-description: Looks up Cloudinary implementation details from official documentation using llms.txt. Use when working with Cloudinary SDKs, upload APIs, account configuration, webhooks, or integration guides. For building or debugging transformation URLs, use a more specialized approach.
+description: Looks up implementation details in the latest Cloudinary docs via llms.txt. Use when building code or answering questions relating to image or video uploads, optimization, or transformations, and for Cloudinary SDKs, APIs, webhooks, or integrations.
 ---
 
 # Cloudinary Documentation
@@ -9,19 +9,21 @@ Helps developers integrate Cloudinary into their applications by providing docum
 
 ## When to Use
 
+- When a user asks questions or requests code implementation relating to image or video upload, management, optimization, or transformations (resizing, applying effects, visual improvements, adding overlays, generative AI, etc.)
 - User asks about Cloudinary SDKs, upload APIs, or integration guides
 - General Cloudinary documentation lookup (account settings, webhooks, DAM features)
-- Looking up specific API endpoints or SDK methods
+- Looking up specific Cloudinary API endpoints or SDK methods
+- Use this skill in conjunction with more specialized Cloudinary skills when relevant.
 
 ## Instructions
 
-When answering questions about Cloudinary:
+When answering image and video upload, management, optimization, or transformation questions or when implementing Cloudinary code:
 
 1. **First, get the documentation index** using llms.txt with the llms.txt URL - https://cloudinary.com/documentation/llms.txt
 2. **Analyze the llms.txt content** to understand what documentation pages are available
 3. **Reflect on the user's question** and identify which specific documentation URLs would be most relevant
 4. **Navigate** to the specific relevant documentation URLs from the llms.txt index (you can make multiple calls)
-5. **Use the fetched documentation** to provide a comprehensive, accurate answer
+5. **Use the fetched documentation** to provide a comprehensive, accurate answer or code implementation.  When relevant, use in conjunction with more specialized Cloudinary skills like cloudinary-transformations. The best practices defined in the specialized skills should guide which doc instructions to use.
 
 Example workflows:
 

--- a/skills/cloudinary-react/SKILL.md
+++ b/skills/cloudinary-react/SKILL.md
@@ -1,11 +1,16 @@
 ---
 name: cloudinary-react
-description: React-specific patterns, best practices, and troubleshooting for Cloudinary SDK integration. Use when building React apps with Cloudinary, implementing Upload Widget, AdvancedImage/AdvancedVideo components, image/video transformations, overlays, signed uploads, Video Player, or debugging Cloudinary React errors (wrong imports, createUploadWidget issues, transformation syntax, TypeScript errors).
+description: Provides opinionated React SDK patterns for configuration, common integration scenarios, and troubleshooting for frequent errors and TypeScript pitfalls. Use when writing code or answering questions related to the Cloudinary React SDK.
 ---
 
 # Cloudinary React Skill
 
-Use this skill when working with Cloudinary in React (web) projects. It provides correct patterns for setup, env vars, Upload Widget, video player, transformations, overlays, and signed uploads, plus solutions to common errors.
+## When to Use
+
+- When a user is building or debugging Cloudinary in a **React** app (Vite, Create React App, Next.js, Parcel, etc.).
+- When implementing or fixing: Upload Widget, AdvancedImage/AdvancedVideo, transformations, overlays, image galleries, video player, or signed/unsigned uploads.
+- When the user sees errors like "createUploadWidget is not a function", wrong imports from `@cloudinary/url-gen`, upload preset issues, or video player DOM errors.
+
 
 ## Quick Start
 
@@ -20,11 +25,7 @@ Use this skill when working with Cloudinary in React (web) projects. It provides
 **For TypeScript**: See [references/typescript-patterns.md](references/typescript-patterns.md)
 **For Video Player**: See [references/video-player.md](references/video-player.md)
 
-## When to Use
 
-- Use this skill when a user is building or debugging Cloudinary in a **React** app (Vite, Create React App, Next.js, Parcel, etc.).
-- Use this skill when implementing or fixing: Upload Widget, AdvancedImage/AdvancedVideo, transformations, overlays, image galleries, video player, or signed/unsigned uploads.
-- Use this skill when the user sees errors like "createUploadWidget is not a function", wrong imports from `@cloudinary/url-gen`, upload preset issues, or video player DOM errors.
 
 ## Instructions
 

--- a/skills/cloudinary-react/SKILL.md
+++ b/skills/cloudinary-react/SKILL.md
@@ -7,7 +7,7 @@ description: Provides opinionated React SDK patterns for configuration, common i
 
 ## When to Use
 
-- When a user is building or debugging Cloudinary in a **React** app (Vite, Create React App, Next.js, Parcel, etc.).
+- When a user is building or debugging Cloudinary in a **React** app (Vite, Create React App, Parcel, etc.).
 - When implementing or fixing: Upload Widget, AdvancedImage/AdvancedVideo, transformations, overlays, image galleries, video player, or signed/unsigned uploads.
 - When the user sees errors like "createUploadWidget is not a function", wrong imports from `@cloudinary/url-gen`, upload preset issues, or video player DOM errors.
 

--- a/skills/cloudinary-transformations/SKILL.md
+++ b/skills/cloudinary-transformations/SKILL.md
@@ -5,7 +5,13 @@ description: Create and debug Cloudinary transformation URLs from natural langua
 
 # Cloudinary Transformation Rules
 
-This skill helps you create valid Cloudinary transformation URLs from natural language instructions and debug transformation issues.
+## When to Use
+
+- Building Cloudinary delivery/transformation URLs
+- Converting natural language requests to transformation syntax
+- Debugging transformation URLs that aren't working
+- Optimizing images or videos with Cloudinary
+- Applying effects, overlays, resizing, or cropping
 
 ## Quick Start
 
@@ -35,13 +41,6 @@ This skill helps you create valid Cloudinary transformation URLs from natural la
 
 **For debugging:** See [references/debugging.md](references/debugging.md) for detailed troubleshooting steps.
 
-## When to Use This Skill
-
-- Building Cloudinary delivery/transformation URLs
-- Converting natural language requests to transformation syntax
-- Debugging transformation URLs that aren't working
-- Optimizing images or videos with Cloudinary
-- Applying effects, overlays, resizing, or cropping
 
 ## Gathering Requirements
 


### PR DESCRIPTION
* Updated readme skill descriptions - All now start with verbs & have a Use When sentence.
* Update Doc skill description to clarify using for any questions related to image or video, and not only Cld-specific questions. Description is just under 250 chars.
* Shortened cloudinary-react description to be under the recommended 250 chars
* Moved `When to Use` heading before `Quick Start` and removed "this skill" phrase from the heading