### PR TITLE
Fix transformation skill issues (10, 11 and 12)

### DIFF
--- a/skills/cloudinary-transformations/SKILL.md
+++ b/skills/cloudinary-transformations/SKILL.md
@@ -4,7 +4,7 @@ description: Create and debug Cloudinary transformation URLs from natural langua
 license: MIT
 metadata:
   author: cloudinary
-  version: '1.0.1'
+  version: '1.0.2'
 ---
 
 # Cloudinary Transformation Rules

--- a/skills/cloudinary-transformations/references/advanced-features.md
+++ b/skills/cloudinary-transformations/references/advanced-features.md
@@ -479,7 +479,7 @@ Font size scales to 10% of image width.
 ### Conditional Overlay Based on Tags
 
 ```
-if_!watermark!_nin_tags/if_end/if_!premium!_in_tags/l_premium_badge/fl_layer_apply,g_north_east/if_end/f_auto/q_auto
+if_!watermark!_nin_tags/if_!premium!_in_tags/l_premium_badge/fl_layer_apply,g_north_east/if_end/if_end/f_auto/q_auto
 ```
 - Skip everything if "watermark" tag present
 - Add premium badge if "premium" tag present
@@ -602,7 +602,7 @@ Different seasonal icons based on context.
 ### Responsive Image Grid
 
 ```
-$cols_3,$gutter_20,$container_1200/c_fill,g_auto,w_$container_sub_$gutter_mul_$cols_add_1_div_$cols/if_ar_gt_1.0/ar_16:9/if_else/ar_1:1/if_end/f_auto/q_auto
+$cols_3,$gutter_20,$container_1200,$slots_$cols_add_1,$totalgutter_$slots_mul_$gutter,$avail_$container_sub_$totalgutter/c_fill,g_auto,w_$avail_div_$cols/if_ar_gt_1.0/c_fill,ar_16:9,w_$avail_div_$cols/if_else/c_fill,ar_1:1,w_$avail_div_$cols/if_end/f_auto/q_auto
 ```
 Calculates grid item width: (container - (gutter × (cols + 1))) ÷ cols
 

--- a/skills/cloudinary-transformations/references/named-transformations.md
+++ b/skills/cloudinary-transformations/references/named-transformations.md
@@ -43,7 +43,7 @@ t_product_thumb   # where product_thumb includes f_auto
 t_product_thumb/f_auto/q_auto
 ```
 
-See [Limitations of named transformations](https://cloudinary.com/documentation/image_transformations#limitations_of_named_transformations.md) for complete details.
+See [Limitations of named transformations](https://cloudinary.com/documentation/image_transformations.md#limitations_of_named_transformations) for complete details.
 
 ## Baseline Transformations
 


### PR DESCRIPTION
Fix transformation skill issues (10, 11 and 12):

- Fixed nested conditional structure for the tag-based overlay example
- Fixed arithmetic ordering, variable names, and aspect ratio handling in the Responsive Image Grid example
- Fixed a malformed documentation link in named-transformations.md