### PR TITLE
Fix fl_splice image side-by-side example (silent no-op)

### DIFF
--- a/skills/cloudinary-transformations/SKILL.md
+++ b/skills/cloudinary-transformations/SKILL.md
@@ -341,13 +341,16 @@ a_auto_right            # Auto-fix from EXIF
 
 ### Asset Type Matters (Image vs. Video)
 
-Some flags and parameters require a **video** base. On an image they are silently ignored — the URL still returns a valid `200`, so verify the actual output (dimensions, duration, frame count) rather than assuming it worked.
+Many flags and parameters apply to only one asset type. Applying one to the wrong base often **fails silently** — the URL still returns a valid `200` with no `X-Cld-Error`, just the wrong output. This goes both ways: video-only syntax on an image, and image-only syntax on a video. Always verify the actual output (dimensions, duration, frame count) rather than assuming it worked.
 
-**These need a video base:**
+**Common video-only examples** (this is *not* an exhaustive list — ~35 parameters are video-only):
 - **`fl_splice`** (flag) - Concatenate a clip/image onto the video timeline (no image equivalent — to place media side-by-side, offset the overlay to extend the canvas: `fl_layer_apply,g_west,x_<base_width>`)
 - **`du_`, `so_`, `eo_`** - Trim/seek by time (duration, start offset, end offset)
 - **`fps_`** - Set frame rate
 - **`vc_`, `ac_`** - Video / audio codec
+- **`e_boomerang`, `e_progressbar`** - Video-only effects
+
+**When unsure whether a flag or parameter supports your asset type, check the [Transformation Reference](https://cloudinary.com/documentation/transformation_reference.md?install_source=skillspack&referrer=trans-skill) before applying it.**
 
 ## Named Transformations
 
@@ -436,7 +439,7 @@ For complete syntax, arithmetic operations, nested conditionals, and real-world 
 7. ✅ **`g_auto` compatibility** (only works with `c_fill`, `c_lfill`, `c_crop`, `c_thumb`, `c_auto`)
 8. ✅ **Background as qualifier** (use with pad crop: `b_color,c_pad,w_X`, not `/b_color/`)
 9. ✅ **Format/quality at end** (prefer `f_auto/q_auto` as final components)
-10. ✅ **Flags/parameters match the base asset type** (video-oriented syntax like the `fl_splice` flag and `du_`, `fps_`, `vc_` parameters need a video base; they no-op silently on images — see [Asset Type Matters](#asset-type-matters-image-vs-video))
+10. ✅ **Flags/parameters match the base asset type** (asset-type-specific syntax — e.g. video-only `fl_splice`, `du_`, `fps_`, `vc_` — often no-ops silently on the wrong base, in either direction; verify the output and check the reference when unsure — see [Asset Type Matters](#asset-type-matters-image-vs-video))
 
 **Quick syntax check:**
 - Commas separate parameters within a component: `c_fill,g_auto,w_400`

--- a/skills/cloudinary-transformations/SKILL.md
+++ b/skills/cloudinary-transformations/SKILL.md
@@ -127,6 +127,15 @@ Check the [Transformation Reference](https://cloudinary.com/documentation/transf
 
 ## Core Transformations
 
+### Asset Type Matters (Image vs. Video)
+
+⚠️ Many flags and parameters behave differently — or do **nothing** — depending on whether the transformation's **base asset** is an image or a video. A misapplied flag often **fails silently**: HTTP 200, a valid asset, no `X-Cld-Error`, just the wrong output. The URL looks correct, so the mistake is easy to miss.
+
+**Rules:**
+- **Know the asset type a flag applies to.** Before using a flag, confirm it's valid for the base asset. Video-oriented flags (e.g. `fl_splice` for concatenation, `du_`/`so_`/`eo_` for timing, `fps_`, `vc_`, `ac_`) require a **video** base; on an image base they are typically ignored.
+- **A 200 is not validation.** Silent no-ops return success. When behavior depends on asset type, verify the *actual output* (e.g. dimensions, frame count) — don't assume it worked because the URL resolved. See [Self-Validation](#self-validation-checklist) and the demo-cloud check in [references/debugging.md](references/debugging.md).
+- **Same flag, different effect.** Some flags exist for both but mean different things (e.g. `fl_splice` concatenates onto a *video* timeline; for an *image* side-by-side you offset the overlay to extend the canvas instead — see [Overlays & Underlays](#overlays--underlays)). State which asset type you mean.
+
 ### Resize & Crop
 
 **Dimension value formats:**
@@ -426,6 +435,7 @@ For complete syntax, arithmetic operations, nested conditionals, and real-world 
 7. ✅ **`g_auto` compatibility** (only works with `c_fill`, `c_lfill`, `c_crop`, `c_thumb`, `c_auto`)
 8. ✅ **Background as qualifier** (use with pad crop: `b_color,c_pad,w_X`, not `/b_color/`)
 9. ✅ **Format/quality at end** (prefer `f_auto/q_auto` as final components)
+10. ✅ **Flags match the base asset type** (video-oriented flags like `fl_splice`, `du_`, `fps_`, `vc_` need a video base; they no-op silently on images — see [Asset Type Matters](#asset-type-matters-image-vs-video))
 
 **Quick syntax check:**
 - Commas separate parameters within a component: `c_fill,g_auto,w_400`

--- a/skills/cloudinary-transformations/SKILL.md
+++ b/skills/cloudinary-transformations/SKILL.md
@@ -289,7 +289,7 @@ c_fill,h_400,w_300/l_same_image/c_fill,e_grayscale,h_400,w_300/fl_layer_apply,g_
 **Important**: 
 - Color (`co_`) is a qualifier — use in the **same component** as text overlay declaration
 - **Always use `fl_relative`** when you want overlay dimensions as a percentage of the base image
-- **Side-by-side / canvas extension**: to place an overlay *beside* the base (not on top), offset it past the base edge — the canvas auto-expands. Use `g_west,x_<base_width>` for horizontal or `g_north,y_<base_height>` for vertical. Do **not** use `fl_splice` to do this on an image — `fl_splice` concatenates onto a video timeline, so on an image base it is silently ignored (composites on top, no error). It does apply when the base is a video (including splicing an image into a video — see video-transformations.md)
+- **Side-by-side / canvas extension**: to place an overlay *beside* the base, offset it past the base edge — the canvas auto-expands. Use `g_west,x_<base_width>` for horizontal or `g_north,y_<base_height>` for vertical.
 
 ### Borders & Rounding
 
@@ -341,10 +341,10 @@ a_auto_right            # Auto-fix from EXIF
 
 ### Asset Type Matters (Image vs. Video)
 
-Some flags require a **video** base. On an image they are silently ignored — the URL still returns a valid `200`, so verify the actual output (dimensions, duration, frame count) rather than assuming it worked.
+Some flags and parameters require a **video** base. On an image they are silently ignored — the URL still returns a valid `200`, so verify the actual output (dimensions, duration, frame count) rather than assuming it worked.
 
-**These flags need a video base:**
-- **`fl_splice`** - Concatenate a clip/image onto the video timeline (no image equivalent — to place media side-by-side, offset the overlay to extend the canvas: `fl_layer_apply,g_west,x_<base_width>`)
+**These need a video base:**
+- **`fl_splice`** (flag) - Concatenate a clip/image onto the video timeline (no image equivalent — to place media side-by-side, offset the overlay to extend the canvas: `fl_layer_apply,g_west,x_<base_width>`)
 - **`du_`, `so_`, `eo_`** - Trim/seek by time (duration, start offset, end offset)
 - **`fps_`** - Set frame rate
 - **`vc_`, `ac_`** - Video / audio codec
@@ -436,7 +436,7 @@ For complete syntax, arithmetic operations, nested conditionals, and real-world 
 7. ✅ **`g_auto` compatibility** (only works with `c_fill`, `c_lfill`, `c_crop`, `c_thumb`, `c_auto`)
 8. ✅ **Background as qualifier** (use with pad crop: `b_color,c_pad,w_X`, not `/b_color/`)
 9. ✅ **Format/quality at end** (prefer `f_auto/q_auto` as final components)
-10. ✅ **Flags match the base asset type** (video-oriented flags like `fl_splice`, `du_`, `fps_`, `vc_` need a video base; they no-op silently on images — see [Asset Type Matters](#asset-type-matters-image-vs-video))
+10. ✅ **Flags/parameters match the base asset type** (video-oriented syntax like the `fl_splice` flag and `du_`, `fps_`, `vc_` parameters need a video base; they no-op silently on images — see [Asset Type Matters](#asset-type-matters-image-vs-video))
 
 **Quick syntax check:**
 - Commas separate parameters within a component: `c_fill,g_auto,w_400`

--- a/skills/cloudinary-transformations/SKILL.md
+++ b/skills/cloudinary-transformations/SKILL.md
@@ -4,7 +4,7 @@ description: Create and debug Cloudinary transformation URLs from natural langua
 license: MIT
 metadata:
   author: cloudinary
-  version: '1.0.2'
+  version: '1.0.3'
 ---
 
 # Cloudinary Transformation Rules

--- a/skills/cloudinary-transformations/SKILL.md
+++ b/skills/cloudinary-transformations/SKILL.md
@@ -283,11 +283,13 @@ l_logo/c_scale,fl_relative,w_0.25/fl_layer_apply,g_north_west,x_10,y_10  # Logo 
 l_docs:one_black_pixel/c_scale,fl_relative,h_1.0,w_1.0/o_50/fl_layer_apply # Full-image semi-transparent overlay
 co_yellow,l_text:Arial_40:Hello%20World/fl_layer_apply,g_south            # Text overlay
 u_background/e_background_removal                                          # Custom background
+c_fill,h_400,w_300/l_same_image/c_fill,e_grayscale,h_400,w_300/fl_layer_apply,g_west,x_300 # Side-by-side (600×400)
 ```
 
 **Important**: 
 - Color (`co_`) is a qualifier — use in the **same component** as text overlay declaration
 - **Always use `fl_relative`** when you want overlay dimensions as a percentage of the base image
+- **Side-by-side / canvas extension**: to place an overlay *beside* the base (not on top), offset it past the base edge — the canvas auto-expands. Use `g_west,x_<base_width>` for horizontal or `g_north,y_<base_height>` for vertical. Do **not** use `fl_splice` for images — it is a video-only concatenation flag and is silently ignored on images (composites on top, no error)
 
 ### Borders & Rounding
 

--- a/skills/cloudinary-transformations/SKILL.md
+++ b/skills/cloudinary-transformations/SKILL.md
@@ -127,15 +127,6 @@ Check the [Transformation Reference](https://cloudinary.com/documentation/transf
 
 ## Core Transformations
 
-### Asset Type Matters (Image vs. Video)
-
-⚠️ Many flags and parameters behave differently — or do **nothing** — depending on whether the transformation's **base asset** is an image or a video. A misapplied flag often **fails silently**: HTTP 200, a valid asset, no `X-Cld-Error`, just the wrong output. The URL looks correct, so the mistake is easy to miss.
-
-**Rules:**
-- **Know the asset type a flag applies to.** Before using a flag, confirm it's valid for the base asset. Video-oriented flags (e.g. `fl_splice` for concatenation, `du_`/`so_`/`eo_` for timing, `fps_`, `vc_`, `ac_`) require a **video** base; on an image base they are typically ignored.
-- **A 200 is not validation.** Silent no-ops return success. When behavior depends on asset type, verify the *actual output* (e.g. dimensions, frame count) — don't assume it worked because the URL resolved. See [Self-Validation](#self-validation-checklist) and the demo-cloud check in [references/debugging.md](references/debugging.md).
-- **Same flag, different effect.** Some flags exist for both but mean different things (e.g. `fl_splice` concatenates onto a *video* timeline; for an *image* side-by-side you offset the overlay to extend the canvas instead — see [Overlays & Underlays](#overlays--underlays)). State which asset type you mean.
-
 ### Resize & Crop
 
 **Dimension value formats:**
@@ -347,6 +338,16 @@ a_-2                    # Straighten slight tilt
 a_hflip                 # Mirror horizontally
 a_auto_right            # Auto-fix from EXIF
 ```
+
+### Asset Type Matters (Image vs. Video)
+
+Some flags require a **video** base. On an image they are silently ignored — the URL still returns a valid `200`, so verify the actual output (dimensions, duration, frame count) rather than assuming it worked.
+
+**These flags need a video base:**
+- **`fl_splice`** - Concatenate a clip/image onto the video timeline (no image equivalent — to place media side-by-side, offset the overlay to extend the canvas: `fl_layer_apply,g_west,x_<base_width>`)
+- **`du_`, `so_`, `eo_`** - Trim/seek by time (duration, start offset, end offset)
+- **`fps_`** - Set frame rate
+- **`vc_`, `ac_`** - Video / audio codec
 
 ## Named Transformations
 

--- a/skills/cloudinary-transformations/SKILL.md
+++ b/skills/cloudinary-transformations/SKILL.md
@@ -289,7 +289,7 @@ c_fill,h_400,w_300/l_same_image/c_fill,e_grayscale,h_400,w_300/fl_layer_apply,g_
 **Important**: 
 - Color (`co_`) is a qualifier — use in the **same component** as text overlay declaration
 - **Always use `fl_relative`** when you want overlay dimensions as a percentage of the base image
-- **Side-by-side / canvas extension**: to place an overlay *beside* the base (not on top), offset it past the base edge — the canvas auto-expands. Use `g_west,x_<base_width>` for horizontal or `g_north,y_<base_height>` for vertical. Do **not** use `fl_splice` for images — it is a video-only concatenation flag and is silently ignored on images (composites on top, no error)
+- **Side-by-side / canvas extension**: to place an overlay *beside* the base (not on top), offset it past the base edge — the canvas auto-expands. Use `g_west,x_<base_width>` for horizontal or `g_north,y_<base_height>` for vertical. Do **not** use `fl_splice` to do this on an image — `fl_splice` concatenates onto a video timeline, so on an image base it is silently ignored (composites on top, no error). It does apply when the base is a video (including splicing an image into a video — see video-transformations.md)
 
 ### Borders & Rounding
 

--- a/skills/cloudinary-transformations/references/examples.md
+++ b/skills/cloudinary-transformations/references/examples.md
@@ -339,7 +339,7 @@ c_fill,g_auto,h_630,w_1200/co_white,l_text:Arial_80_bold:Breaking%20News/b_black
 ```
 c_fill,h_400,w_300/l_same_image/c_fill,e_grayscale,h_400,w_300/fl_layer_apply,g_west,x_300/f_auto/q_auto
 ```
-Creates a true side-by-side comparison (600×400) with a grayscale version. The canvas auto-expands when the overlay is offset past the base edge — set `x_<base_width>` (or `y_<base_height>` for vertical stacking). Do **not** use `fl_splice` here: it concatenates onto a **video** timeline, so on an image base it is silently ignored (the overlay composites on top instead, leaving a 300×400 result with no error). See [Video Concatenation](video-transformations.md#video-concatenation-fl_splice) for `fl_splice` usage, including splicing images into videos.
+Creates a true side-by-side comparison (600×400) with a grayscale version. Offset the overlay past the base edge to make the canvas auto-expand — set `x_<base_width>` for horizontal (or `y_<base_height>` to stack vertically).
 
 ## Video Transformations
 

--- a/skills/cloudinary-transformations/references/examples.md
+++ b/skills/cloudinary-transformations/references/examples.md
@@ -339,7 +339,7 @@ c_fill,g_auto,h_630,w_1200/co_white,l_text:Arial_80_bold:Breaking%20News/b_black
 ```
 c_fill,h_400,w_300/l_same_image/c_fill,e_grayscale,h_400,w_300/fl_layer_apply,g_west,x_300/f_auto/q_auto
 ```
-Creates a true side-by-side comparison (600×400) with a grayscale version. The canvas auto-expands when the overlay is offset past the base edge — set `x_<base_width>` (or `y_<base_height>` for vertical stacking). Do **not** use `fl_splice` here: it is a video-only concatenation flag, silently ignored on images (the overlay composites on top instead, leaving a 300×400 result with no error).
+Creates a true side-by-side comparison (600×400) with a grayscale version. The canvas auto-expands when the overlay is offset past the base edge — set `x_<base_width>` (or `y_<base_height>` for vertical stacking). Do **not** use `fl_splice` here: it concatenates onto a **video** timeline, so on an image base it is silently ignored (the overlay composites on top instead, leaving a 300×400 result with no error). See [Video Concatenation](video-transformations.md#video-concatenation-fl_splice) for `fl_splice` usage, including splicing images into videos.
 
 ## Video Transformations
 

--- a/skills/cloudinary-transformations/references/examples.md
+++ b/skills/cloudinary-transformations/references/examples.md
@@ -337,9 +337,9 @@ c_fill,g_auto,h_630,w_1200/co_white,l_text:Arial_80_bold:Breaking%20News/b_black
 
 ### Before/After Comparison
 ```
-c_fill,h_400,w_300/l_same_image/c_fill,e_grayscale,h_400,w_300/fl_layer_apply,fl_splice,g_east/f_auto/q_auto
+c_fill,h_400,w_300/l_same_image/c_fill,e_grayscale,h_400,w_300/fl_layer_apply,g_west,x_300/f_auto/q_auto
 ```
-Creates side-by-side comparison with grayscale version.
+Creates a true side-by-side comparison (600×400) with a grayscale version. The canvas auto-expands when the overlay is offset past the base edge — set `x_<base_width>` (or `y_<base_height>` for vertical stacking). Do **not** use `fl_splice` here: it is a video-only concatenation flag, silently ignored on images (the overlay composites on top instead, leaving a 300×400 result with no error).
 
 ## Video Transformations
 

--- a/skills/cloudinary-transformations/references/video-transformations.md
+++ b/skills/cloudinary-transformations/references/video-transformations.md
@@ -49,7 +49,7 @@ fps_20-25                      # FPS range
 
 ## Video Concatenation (`fl_splice`)
 
-**Requires a video base.** `fl_splice` concatenates a clip onto a video timeline — the spliced-in asset can be another video *or* an image ([splicing images into videos](https://cloudinary.com/documentation/video_concatenation#concatenate_videos_with_images); use `du_<seconds>` to set how long the image shows). It only works when the **base** of the transformation is a video. On an image-only transformation there is no timeline, so `fl_splice` is silently ignored (no `X-Cld-Error`, valid 200 response) and the overlay composites on top instead of extending the canvas. For an image side-by-side, offset the overlay past the base edge to auto-expand the canvas (`fl_layer_apply,g_west,x_<base_width>`), not `fl_splice`.
+**Requires a video base.** `fl_splice` concatenates a clip onto a video timeline; the spliced-in asset can be a video or an [image](https://cloudinary.com/documentation/video_concatenation#concatenate_videos_with_images) (set its duration with `du_<seconds>`). It is ignored on image-only transformations.
 
 **Pattern:**
 1. Declare: `fl_splice,l_video:<public_id>`

--- a/skills/cloudinary-transformations/references/video-transformations.md
+++ b/skills/cloudinary-transformations/references/video-transformations.md
@@ -49,7 +49,7 @@ fps_20-25                      # FPS range
 
 ## Video Concatenation (`fl_splice`)
 
-**Video only.** `fl_splice` concatenates video clips. It is silently ignored on images (no `X-Cld-Error`, valid 200 response) — the overlay composites normally instead of extending the canvas. For an image side-by-side, offset the overlay past the base edge to auto-expand the canvas (`fl_layer_apply,g_west,x_<base_width>`), not `fl_splice`.
+**Requires a video base.** `fl_splice` concatenates a clip onto a video timeline — the spliced-in asset can be another video *or* an image ([splicing images into videos](https://cloudinary.com/documentation/video_concatenation#concatenate_videos_with_images); use `du_<seconds>` to set how long the image shows). It only works when the **base** of the transformation is a video. On an image-only transformation there is no timeline, so `fl_splice` is silently ignored (no `X-Cld-Error`, valid 200 response) and the overlay composites on top instead of extending the canvas. For an image side-by-side, offset the overlay past the base edge to auto-expand the canvas (`fl_layer_apply,g_west,x_<base_width>`), not `fl_splice`.
 
 **Pattern:**
 1. Declare: `fl_splice,l_video:<public_id>`

--- a/skills/cloudinary-transformations/references/video-transformations.md
+++ b/skills/cloudinary-transformations/references/video-transformations.md
@@ -49,7 +49,7 @@ fps_20-25                      # FPS range
 
 ## Video Concatenation (`fl_splice`)
 
-**Requires a video base.** `fl_splice` concatenates a clip onto a video timeline; the spliced-in asset can be a video or an [image](https://cloudinary.com/documentation/video_concatenation#concatenate_videos_with_images) (set its duration with `du_<seconds>`). It is ignored on image-only transformations.
+**Requires a video base.** `fl_splice` concatenates a clip onto a video timeline; the spliced-in asset can be a video or an [image](https://cloudinary.com/documentation/video_concatenation.md?install_source=skillspack&referrer=trans-skill#concatenate_videos_with_images) (set its duration with `du_<seconds>`). It is ignored on image-only transformations.
 
 **Pattern:**
 1. Declare: `fl_splice,l_video:<public_id>`

--- a/skills/cloudinary-transformations/references/video-transformations.md
+++ b/skills/cloudinary-transformations/references/video-transformations.md
@@ -49,6 +49,8 @@ fps_20-25                      # FPS range
 
 ## Video Concatenation (`fl_splice`)
 
+**Video only.** `fl_splice` concatenates video clips. It is silently ignored on images (no `X-Cld-Error`, valid 200 response) — the overlay composites normally instead of extending the canvas. For an image side-by-side, offset the overlay past the base edge to auto-expand the canvas (`fl_layer_apply,g_west,x_<base_width>`), not `fl_splice`.
+
 **Pattern:**
 1. Declare: `fl_splice,l_video:<public_id>`
 2. Transform overlay (optional)


### PR DESCRIPTION
## Problem

The `cloudinary-transformations` skill's "Before/After Comparison" example used `fl_splice` to build an image side-by-side:

```
c_fill,h_400,w_300/l_same_image/c_fill,e_grayscale,h_400,w_300/fl_layer_apply,fl_splice,g_east/f_auto/q_auto
```

`fl_splice` is a **video-only** concatenation flag. Applied to an image overlay it is silently ignored — the layer composites on top of the base instead of extending the canvas. The request returns **HTTP 200 with no `X-Cld-Error`**, so the failure is invisible: the URL looks valid and returns a valid image, it's just the wrong one.

## Verification

Reproduced against the demo cloud (`l_sample` standing in for the `l_same_image` placeholder):

| URL | Result |
|---|---|
| `…/fl_layer_apply,fl_splice,g_east/…` (original) | **300×400** — single frame, splice ignored |
| `…/fl_layer_apply,g_west,x_300/…` (fix) | **600×400** — true side-by-side |

Both returned HTTP 200 with no `X-Cld-Error`.

## Fix

For images, extend the canvas by offsetting the overlay past the base edge (`x_<base_width>`); the canvas auto-expands.

- **examples.md** — swap `fl_splice,g_east` → `g_west,x_300`; explain the canvas auto-expansion and the `fl_splice` image trap.
- **video-transformations.md** — mark `fl_splice` "Video only" with the silent no-op note and a pointer to the image offset technique.
- **SKILL.md** — surface the canvas-extension technique in the Overlays section so side-by-side is discoverable from the main skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)